### PR TITLE
Add method 'addPoint' to PresetInterpolator

### DIFF
--- a/interpolator/PresetInterpolator.sc
+++ b/interpolator/PresetInterpolator.sc
@@ -113,7 +113,7 @@ PresetInterpolator {
 		};
 		this.initActions;
 	}
-	
+
 	initActions {
 		actions = IdentityDictionary[
 			\weights -> {|model, what, interPoints, weights|
@@ -174,7 +174,7 @@ PresetInterpolator {
 			}
 		];
 	}
-	
+
 	save { |path|
 		path = path ? (Platform.userAppSupportDir ++"/scratchPreset.pri");
 		(
@@ -187,6 +187,10 @@ PresetInterpolator {
 	}
 
 	// access to model
+	addPoint { |point|
+		model.add(point);
+	}
+
 	getPresetColor {|i|
 		^model.colors[i];
 	}


### PR DESCRIPTION
This is a convenience method which mimics the "Add Point" button from the PresetInterpolator GUI. 